### PR TITLE
Ignore CVE in Pylint

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,13 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-PYTHON-PYLINT-1089548:
+    - '*':
+        reason: Present in code lint
+        created: 2022-10-11T12:01:26.252Z
+  SNYK-PYTHON-PYLINT-609883:
+    - '*':
+        reason: Present in code lint
+        created: 2022-10-11T12:01:26.252Z
+patch: {}


### PR DESCRIPTION
    Upgrade pylint@2.5.3 to pylint@2.7.0 to fix
    ✗ Regular Expression Denial of Service (ReDoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-PYLINT-1089548] in pylint@2.5.3
      introduced by pylint@2.5.3 and 15 other path(s)
    ✗ Regular Expression Denial of Service (ReDoS) [High Severity][https://security.snyk.io/vuln/SNYK-PYTHON-PYLINT-609883] in pylint@2.5.3
      introduced by pylint@2.5.3 and 15 other path(s)