### PR TITLE
Fix CVE

### DIFF
--- a/app/poetry.lock
+++ b/app/poetry.lock
@@ -1474,14 +1474,14 @@ files = [
 
 [[package]]
 name = "redis"
-version = "4.4.0"
+version = "4.4.4"
 description = "Python client for Redis database and key-value store"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "redis-4.4.0-py3-none-any.whl", hash = "sha256:cae3ee5d1f57d8caf534cd8764edf3163c77e073bdd74b6f54a87ffafdc5e7d9"},
-    {file = "redis-4.4.0.tar.gz", hash = "sha256:7b8c87d19c45d3f1271b124858d2a5c13160c4e74d4835e28273400fa34d5228"},
+    {file = "redis-4.4.4-py3-none-any.whl", hash = "sha256:da92a39fec86438d3f1e2a1db33c312985806954fe860120b582a8430e231d8f"},
+    {file = "redis-4.4.4.tar.gz", hash = "sha256:68226f7ede928db8302f29ab088a157f41061fa946b7ae865452b6d7838bbffb"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
    Pin redis@4.4.0 to redis@4.4.4 to fix
    ✗ Exposure of Data Element to Wrong Session (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-REDIS-5291196] in redis@4.4.0
      introduced by c2cwsgiutils@5.1.6 > redis@4.4.0