### PR TITLE
Fix CVE

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,5 +1,5 @@
 c2cciutils==1.0
-pip>=21.1 # not directly required, pinned by Snyk to avoid a vulnerability
+pip>=23.3 # not directly required, pinned by Snyk to avoid a vulnerability
 pipenv>=2022.1.8 # not directly required, pinned by Snyk to avoid a vulnerability
 urllib3>=1.26.5 # not directly required, pinned by Snyk to avoid a vulnerability
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
    Upgrade pip@23.0.1 to pip@23.3 to fix
    ✗ Arbitrary Command Injection (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-PIP-6036008] in pip@23.0.1
      introduced by pip@23.0.1 and 2 other path(s)