### PR TITLE
Use c2casgiutils nonce and route prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,16 @@ A few environment variables can be used to tune the containers:
 - `C2C__REDIS__URL`: Must point to a running Redis (typical: `redis://redis:6379`) for being able to
   broadcast the refresh notifications
 - `SCM__MASTER_CONFIG`: The master configuration (string containing the YAML config)
-- `SCM__ROUTE_PREFIX`: The prefix to use for the HTTP API (defaults to `/scm`)
+- `C2C__ROUTE_PREFIX`: The route prefix used by the ASGI app and HTTP API (defaults to `/` and should start/end with `/`)
 - `SCM__TAG_FILTER`: Load only the sources having the given tag (the master config is always loaded)
 - `SCM__TARGET`: default base directory for the `target_dir` configuration (defaults to `/config`)
 - `SCM__MASTER_TARGET`: where to store the master config (defaults to `/master_config`)
 - `SCM__API_BASE_URL`: how to reach the master for slaves.
 - `SCM__API_MASTER`: if defined, this is a master with slaves (no template evaluation)
 - `SCM__SECRET`: the secret used to authenticate the request between the client and the server
+
+`SCM__API_BASE_URL` should include the effective route prefix configured through `C2C__ROUTE_PREFIX`
+(for example `http://api:8080/scm` when `C2C__ROUTE_PREFIX=/scm/`).
 
 See [https://github.com/camptocamp/c2casgiutils] for other parameters.
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -84,7 +84,8 @@ COPY shared_config_manager/ ./shared_config_manager/
 
 RUN mkdir -p /prometheus-metrics \
     && chmod a+rwx /prometheus-metrics
-ENV PROMETHEUS_MULTIPROC_DIR=/prometheus-metrics
+ENV PROMETHEUS_MULTIPROC_DIR=/prometheus-metrics \
+    C2C__ROUTE_PREFIX=/scm/
 
 CMD ["start", "uvicorn", "shared_config_manager.main:app", "--host=0.0.0.0", "--port=8080", "--log-config=/app/logging.yaml", "--proxy-headers", "--forwarded-allow-ips=*"]
 

--- a/app/shared_config_manager/__init__.py
+++ b/app/shared_config_manager/__init__.py
@@ -1,4 +1,0 @@
-import base64
-import os
-
-nonce = base64.b64encode(os.urandom(16)).decode("utf-8")

--- a/app/shared_config_manager/config.py
+++ b/app/shared_config_manager/config.py
@@ -59,8 +59,6 @@ class Settings(BaseSettings, extra="ignore"):
     """GitHub API token for accessing GitHub commit information."""
     github_secret: str | None = None
     """GitHub webhook secret for validating incoming webhook signatures."""
-    route_prefix: str = "/scm"
-    """Route prefix for the shared config manager API."""
     requests_timeout: float = 30
     """Timeout in seconds for HTTP requests made by the shared config manager."""
 

--- a/app/shared_config_manager/main.py
+++ b/app/shared_config_manager/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import re
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
@@ -15,7 +16,7 @@ from fastapi.responses import RedirectResponse
 from prometheus_client import start_http_server
 from prometheus_fastapi_instrumentator import Instrumentator
 
-from shared_config_manager import api, config, nonce, slave_status, ui
+from shared_config_manager import api, config, slave_status, ui
 from shared_config_manager.sources import base, registry
 
 _LOGGER = logging.getLogger(__name__)
@@ -155,35 +156,30 @@ app.add_middleware(
 _ui_headers: dict[str, str | list[str] | dict[str, str] | dict[str, list[str]] | None] = {
     "Content-Security-Policy": {
         "default-src": ["'self'"],
-        "script-src-elem": ["'self'", f"'nonce-{nonce}'"],
-        "style-src-elem": ["'self'", f"'nonce-{nonce}'", "https://cdnjs.cloudflare.com/"],
-        "style-src-attr": ["'self'"],
+        "script-src-elem": ["'self'", headers.CSP_NONCE],
+        "style-src-elem": ["'self'", headers.CSP_NONCE, "https://cdnjs.cloudflare.com/"],
+        "style-src-attr": ["'none'"],
     },
     "Cache-Control": "max-age=10",
 }
-route_prefix = config.settings.route_prefix
-if route_prefix and route_prefix.startswith("/"):
-    route_prefix = route_prefix[1:]
-if route_prefix and route_prefix.endswith("/"):
-    route_prefix = route_prefix[:-1]
+_route_prefix_regex_base = re.escape(c2casgiutils.config.settings.route_prefix.removeprefix("/"))
 
-_LOGGER.info("Using route prefix: '%s'", route_prefix)
 app.add_middleware(
     headers.ArmorHeaderMiddleware,
     headers_config={
         "http": {"headers": {"Strict-Transport-Security": None} if http else {}},
         "ui_index": {
-            "path_match": rf"{route_prefix}/$",
+            "path_match": rf"^{_route_prefix_regex_base}$",
             "headers": _ui_headers,
             "status_code": 200,
         },
         "ui_sources": {
-            "path_match": rf"{route_prefix}/source/.*",
+            "path_match": rf"^{_route_prefix_regex_base}source/.*",
             "headers": _ui_headers,
             "status_code": 200,
         },
         "api": {
-            "path_match": rf"{route_prefix}/1/.*",
+            "path_match": rf"^{_route_prefix_regex_base}1/.*",
             "headers": {
                 "Cache-Control": "max-age=0, no-cache, no-store, must-revalidate",
             },
@@ -197,7 +193,7 @@ health_checks.FACTORY.add(health_checks.Redis(tags=["liveness", "redis", "all"])
 health_checks.FACTORY.add(health_checks.Wrong(tags=["wrong", "all"]))
 
 
-@app.get(f"{config.settings.route_prefix}/c2c")
+@app.get(f"{c2casgiutils.config.settings.route_prefix}c2c")
 async def redirect_c2c(request: Request) -> RedirectResponse:
     """Redirect to the mounted c2c app canonical path."""
     url = request.url
@@ -208,9 +204,9 @@ async def redirect_c2c(request: Request) -> RedirectResponse:
 
 
 # Add Routers
-app.mount(f"{config.settings.route_prefix}/1", api.app)
-app.mount(f"{config.settings.route_prefix}/c2c", c2casgiutils.app)
-app.mount(f"{config.settings.route_prefix}/", ui.app)
+app.mount(f"{c2casgiutils.config.settings.route_prefix}1", api.app)
+app.mount(f"{c2casgiutils.config.settings.route_prefix}c2c", c2casgiutils.app)
+app.mount(c2casgiutils.config.settings.route_prefix, ui.app)
 
 # Get Prometheus HTTP server port from environment variable 9000 by default
 start_http_server(c2casgiutils.config.settings.prometheus.port)

--- a/app/shared_config_manager/templates/index.html.jinja2
+++ b/app/shared_config_manager/templates/index.html.jinja2
@@ -27,6 +27,7 @@
     <style nonce="{{ nonce }}">
       body { padding-bottom: 1rem; }
       .login-info { text-align: right; }
+      .logout-button { vertical-align: baseline; }
     </style>
     <title>Shared config manager</title>
   </head>
@@ -45,8 +46,8 @@
       <p class="login-info">
       {% if identity is not none %}
       Logged as: <a href="{{ identity.url }}">{{ identity.name }}</a>{% if identity.auth_type == "github_oauth" %},
-      <a role="button" class="btn btn-secondary mt-4"
-      href="{{ url_for('c2c_github_logout') }}?came_from={{ request.url | urlencode }}" style="vertical-align: baseline;">Logout</a>
+      <a role="button" class="btn btn-secondary mt-4 logout-button"
+      href="{{ url_for('c2c_github_logout') }}?came_from={{ request.url | urlencode }}">Logout</a>
       {% endif %}
       {% else %}
       <a class="btn btn-primary"

--- a/app/shared_config_manager/ui.py
+++ b/app/shared_config_manager/ui.py
@@ -14,7 +14,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
-from shared_config_manager import broadcast_status, config, nonce, slave_status
+from shared_config_manager import broadcast_status, config, slave_status
 from shared_config_manager.security import Allowed, User, get_identity, permits
 from shared_config_manager.sources import registry
 from shared_config_manager.sources.base import BaseSource
@@ -89,6 +89,11 @@ async def ui_index(
     valid_sources = list(
         zip(await asyncio.gather(*[_is_valid(source) for source in sources_list]), sources_list, strict=True),
     )
+
+    try:
+        nonce = request.state.nonce
+    except AttributeError as exc:
+        raise HTTPException(status_code=500, detail="CSP nonce not initialized") from exc
 
     return templates.TemplateResponse(
         "index.html.jinja2",
@@ -249,6 +254,11 @@ async def ui_source(
     ) -> str:
         response, _ = elem
         return response.hostname
+
+    try:
+        nonce = request.state.nonce
+    except AttributeError as exc:
+        raise HTTPException(status_code=500, detail="CSP nonce not initialized") from exc
 
     return templates.TemplateResponse(
         "source.html.jinja2",


### PR DESCRIPTION
## Summary
- migrate CSP nonce handling to `c2casgiutils.headers.CSP_NONCE` and use `request.state.nonce` in UI templates instead of an internal static nonce
- switch route prefix usage from internal `SCM__ROUTE_PREFIX` setting to `c2casgiutils` route prefix and centralize regex escaping in a dedicated helper
- remove obsolete internal route-prefix setting, add focused unit test coverage for route-prefix regex helper, and update README configuration docs
