### PR TITLE
Group slave settings under SCM__SLAVE__ and parallelize source loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,4 @@ Test files in `app/tests/` may not follow the rules concerning `async` requireme
 ## Pull Requests
 
 - Do not include a `Testing` section in pull request descriptions unless explicitly requested.
+- Never create git branch names containing `/`; use hyphens instead.

--- a/README.md
+++ b/README.md
@@ -53,14 +53,22 @@ by setting the `sources` section directly at the root of the `MASTER_CONFIG`.
 A few environment variables can be used to tune the containers:
 
 - `SCM__MASTER_CONFIG`: The master configuration (string containing the YAML config)
-- `SCM__TAG_FILTER`: Load only the sources having the given tag (the master config is always loaded)
-- `SCM__TARGET`: default base directory for the `target_dir` configuration (defaults to `/config`)
 - `SCM__MASTER_TARGET`: where to store the master config (defaults to `/master_config`)
-- `SCM__API_BASE_URL`: how to reach the master for slaves.
 - `SCM__API_MASTER`: if defined, this is a master with slaves (no template evaluation)
 - `SCM__SECRET`: the secret used to authenticate the request between the client and the server
 
-`SCM__API_BASE_URL` should include the effective route prefix configured through `C2C__ROUTE_PREFIX`
+Slave-related variables:
+
+- `SCM__SLAVE__ENABLED`: run in slave mode (set to `true` for the slave process)
+- `SCM__SLAVE__API_BASE_URL`: how to reach the master for slaves
+- `SCM__SLAVE__TAG_FILTER`: load only the sources having the given tag (the master config is always loaded)
+- `SCM__SLAVE__TARGET`: default base directory for the `target_dir` configuration (defaults to `/config`)
+- `SCM__SLAVE__RETRY_NUMBER`: retry attempts when fetching from master (defaults to `3`)
+- `SCM__SLAVE__RETRY_DELAY`: delay between retries in seconds (defaults to `1`)
+- `SCM__SLAVE__REQUESTS_TIMEOUT`: timeout in seconds for slave fetch requests (defaults to `30`)
+- `SCM__SLAVE__INIT_SOURCES_CONCURRENCY`: number of sources loaded in parallel while reading master config (defaults to `4`)
+
+`SCM__SLAVE__API_BASE_URL` should include the effective route prefix configured through `C2C__ROUTE_PREFIX`
 (for example `http://api:8080/scm` when `C2C__ROUTE_PREFIX=/scm/`).
 
 See [https://github.com/camptocamp/c2casgiutils] for other parameters.
@@ -73,7 +81,7 @@ See [https://github.com/camptocamp/c2casgiutils] for other parameters.
 - `target_dir`: the location where the source will be copied (default is the value of `id` in `/config`)
 - `excludes`: the list of files/directories to exclude
 - `template_engines`: a list of template engine configurations
-- `tags`: an optional list of tags. Slaves having `TAG_FILTER` defined will load only sources having the matching tag.
+- `tags`: an optional list of tags. Slaves having `SCM__SLAVE__TAG_FILTER` defined will load only sources having the matching tag.
 
 #### GIT source configuration parameters
 
@@ -129,7 +137,7 @@ services:
         type: git
         repo: git@github.com:camptocamp/master_config.git
       SCM__SECRET: changeme
-      SCM__TAG_FILTER: master
+      SCM__SLAVE__TAG_FILTER: master
     links:
       - redis
     labels:

--- a/app/shared_config_manager/config.py
+++ b/app/shared_config_manager/config.py
@@ -4,7 +4,7 @@ import logging
 from typing import Annotated
 
 from anyio import Path
-from pydantic import field_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 from pydantic.functional_validators import BeforeValidator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
@@ -20,33 +20,67 @@ def _to_path(v: object) -> Path:
 _AnyioPath = Annotated[Path, BeforeValidator(_to_path)]
 
 
-class Settings(BaseSettings, extra="ignore"):
-    """The configuration settings."""
+class SlaveSettings(BaseModel):
+    """Slave related settings."""
 
-    is_slave: bool = False
+    model_config = ConfigDict(validate_assignment=True, arbitrary_types_allowed=True)
+
+    enabled: bool = False
     """Whether this instance is a slave (non-master) node. Defaults to False."""
-    secret: str | None = None
-    """Shared secret for internal authentication between master and slave nodes."""
     target: _AnyioPath = Path("/config")
     """Target directory where configuration is deployed on slave nodes."""
-    master_target: _AnyioPath = Path("/master_config")
-    """Target directory where configuration is deployed on the master node."""
     retry_number: int = 3
     """Number of retry attempts when fetching configuration from the master."""
     retry_delay: int = 1
     """Delay in seconds between retry attempts when fetching configuration."""
-    watch_source_interval: int = 600
-    """Interval in seconds to check and refresh source configurations."""
+    init_sources_concurrency: int = 4
+    """Maximum number of sources to load concurrently at startup/reload."""
     api_base_url: str | None = None
     """Base URL for the shared config manager API (with trailing slash)."""
+    tag_filter: str | None = None
+    """Filter sources by tag on slave nodes. Only sources with this tag will be synced."""
+    requests_timeout: float = 30
+    """Timeout in seconds for HTTP requests made by the shared config manager."""
+
+    @field_validator("api_base_url")
+    @classmethod
+    def validate_api_base_url(cls, value: str | None) -> str | None:
+        if value is not None and not value.endswith("/"):
+            value += "/"
+        return value
+
+    @field_validator("init_sources_concurrency")
+    @classmethod
+    def validate_init_sources_concurrency(cls, value: int) -> int:
+        if value < 1:
+            return 1
+        return value
+
+    @model_validator(mode="after")
+    def validate_enabled_requires_api_base_url(self) -> "SlaveSettings":
+        if self.enabled and self.api_base_url is None:
+            msg = "SCM__SLAVE__API_BASE_URL is required when SCM__SLAVE__ENABLED is true"
+            raise ValueError(msg)
+        return self
+
+
+class Settings(BaseSettings, extra="ignore"):
+    """The configuration settings."""
+
+    slave: SlaveSettings = SlaveSettings()
+    """Group containing all slave related configuration."""
+    secret: str | None = None
+    """Shared secret for internal authentication between master and slave nodes."""
+    master_target: _AnyioPath = Path("/master_config")
+    """Target directory where configuration is deployed on the master node."""
+    watch_source_interval: int = 600
+    """Interval in seconds to check and refresh source configurations."""
     api_master: bool = False
     """
     Whether this instance exposes the shared config manager API as the master node.
     When this is True and slave nodes are present, templates will not be rendered
     on the master node (they are rendered only on slave nodes).
     """
-    tag_filter: str | None = None
-    """Filter sources by tag on slave nodes. Only sources with this tag will be synced."""
     master_config: str | None = None
     """Master configuration YAML content as a string (used instead of loading from file)."""
     master_dispatch: bool = True
@@ -59,17 +93,7 @@ class Settings(BaseSettings, extra="ignore"):
     """GitHub API token for accessing GitHub commit information."""
     github_secret: str | None = None
     """GitHub webhook secret for validating incoming webhook signatures."""
-    requests_timeout: float = 30
-    """Timeout in seconds for HTTP requests made by the shared config manager."""
-
     model_config = SettingsConfigDict(env_prefix="SCM__", env_nested_delimiter="__")
-
-    @field_validator("api_base_url")
-    @classmethod
-    def validate_api_base_url(cls, value: str | None) -> str | None:
-        if value is not None and not value.endswith("/"):
-            value += "/"
-        return value
 
     @field_validator("env_prefixes", mode="before")
     @classmethod

--- a/app/shared_config_manager/main.py
+++ b/app/shared_config_manager/main.py
@@ -124,7 +124,7 @@ async def _lifespan(main_app: FastAPI) -> AsyncGenerator[None, None]:
     global _WATCH_SOURCE_TASK  # noqa: PLW0603
     _WATCH_SOURCE_TASK = asyncio.create_task(_watch_source())
 
-    if not config.settings.is_slave:
+    if not config.settings.slave.enabled:
         await registry.init(slave=False)
 
     yield

--- a/app/shared_config_manager/scripts/shared_config_slave.py
+++ b/app/shared_config_manager/scripts/shared_config_slave.py
@@ -34,7 +34,7 @@ async def _async_main() -> None:
     logging_config = yaml.safe_load(await Path("logging.yaml").read_text(encoding="utf-8"))
     logging.config.dictConfig(logging_config)
 
-    config.settings.is_slave = True
+    config.settings.slave.enabled = True
 
     if c2casgiutils.config.settings.prometheus.port is not None:
         prometheus_client.start_http_server(c2casgiutils.config.settings.prometheus.port)

--- a/app/shared_config_manager/sources/base.py
+++ b/app/shared_config_manager/sources/base.py
@@ -125,7 +125,7 @@ class BaseSource:
         path = self.get_path()
         url = mode.get_fetch_url(self.get_id())
 
-        for i in list(range(config.settings.retry_number))[::-1]:
+        for i in list(range(config.settings.slave.retry_number))[::-1]:
             try:
                 _LOG.info("Doing a fetch of %s, on %s", self.get_id(), url)
                 async with (
@@ -133,7 +133,7 @@ class BaseSource:
                     session.get(
                         url,
                         headers={"X-Scm-Secret": config.settings.secret or ""},
-                        timeout=config.settings.requests_timeout,
+                        timeout=config.settings.slave.requests_timeout,
                     ) as response,
                 ):
                     response.raise_for_status()
@@ -160,7 +160,7 @@ class BaseSource:
                 if not isinstance(exception, aiohttp.ClientConnectorError):
                     _LOG.exception("Unexpected error while fetching the source from url %s", url)
                 _DO_FETCH_ERROR_COUNTER.labels(self.get_id()).inc()
-                retry_message = f" (will retry in {config.settings.retry_delay}s)" if i else " (failed)"
+                retry_message = f" (will retry in {config.settings.slave.retry_delay}s)" if i else " (failed)"
                 _LOG.warning(
                     "Error fetching the source %s from the master%s: %s",
                     self.get_id(),
@@ -168,7 +168,7 @@ class BaseSource:
                     str(exception),
                 )
                 if i:
-                    await asyncio.sleep(config.settings.retry_delay)
+                    await asyncio.sleep(config.settings.slave.retry_delay)
                 else:
                     raise
             else:
@@ -205,8 +205,14 @@ class BaseSource:
             target_dir = self._config["target_dir"]
             if target_dir.startswith("/"):
                 return Path(target_dir)
-            return config.settings.master_target if self._is_master else config.settings.target / target_dir
-        return config.settings.master_target if self._is_master else config.settings.target / self.get_id()
+            return (
+                config.settings.master_target
+                if self._is_master
+                else config.settings.slave.target / target_dir
+            )
+        return (
+            config.settings.master_target if self._is_master else config.settings.slave.target / self.get_id()
+        )
 
     def get_id(self) -> str:
         return self._id

--- a/app/shared_config_manager/sources/mode.py
+++ b/app/shared_config_manager/sources/mode.py
@@ -11,7 +11,7 @@ def init(slave: bool) -> None:
 
 def is_master() -> bool:
     """Is the master."""
-    return not _SLAVE or config.settings.api_base_url is None
+    return not _SLAVE or config.settings.slave.api_base_url is None
 
 
 def is_master_with_slaves() -> bool:
@@ -21,4 +21,4 @@ def is_master_with_slaves() -> bool:
 
 def get_fetch_url(id_: str) -> str:
     """Get the URL to fetch the tarball."""
-    return f"{config.settings.api_base_url}1/tarball/{id_}"
+    return f"{config.settings.slave.api_base_url}1/tarball/{id_}"

--- a/app/shared_config_manager/sources/registry.py
+++ b/app/shared_config_manager/sources/registry.py
@@ -101,38 +101,55 @@ async def reload_master_config() -> None:
         await _handle_master_config(cfg)
 
 
-async def _do_handle_master_config(config: configuration.Config) -> tuple[int, int]:
+async def _do_handle_master_config(master_config: configuration.Config) -> tuple[int, int]:
     global FILTERED_SOURCES  # noqa: PLW0603
 
-    success = 0
-    errors = 0
-
-    new_sources, filtered = _filter_sources(config["sources"])
+    new_sources, filtered = _filter_sources(master_config["sources"])
     FILTERED_SOURCES = {
-        source_id: _create_source(source_id, config) for source_id, config in filtered.items()
+        source_id: _create_source(source_id, source_config) for source_id, source_config in filtered.items()
     }
 
     to_deletes = set(_SOURCES.keys()) - set(new_sources.keys())
-    for to_delete in to_deletes:
-        await _delete_source(to_delete)
+    await asyncio.gather(*[_delete_source(to_delete) for to_delete in to_deletes])
+
+    to_reload: dict[str, configuration.SourceConfig] = {}
+    changed_sources: list[str] = []
     for source_id, source_config in new_sources.items():
         prev_source = _SOURCES.get(source_id)
         if prev_source is None:
             _LOG.info("New source detected: %s", source_id)
+            to_reload[source_id] = source_config
         elif prev_source.get_config() == source_config:
             _LOG.debug("Source %s didn't change, not reloading it", source_id)
             continue
         else:
             _LOG.info("Change detected in source %s, reloading it", source_id)
-            await _delete_source(source_id)  # to be sure the old stuff is cleaned
+            changed_sources.append(source_id)
+            to_reload[source_id] = source_config
 
-        try:
-            _SOURCES[source_id] = _create_source(source_id, source_config)
-            await _SOURCES[source_id].refresh_or_fetch()
-            success += 1
-        except Exception:  # noqa: BLE001
-            _LOG.error("Cannot load the %s config", source_id, exc_info=True)
-            errors += 1
+    await asyncio.gather(*[_delete_source(source_id) for source_id in changed_sources])
+
+    if not to_reload:
+        return 0, 0
+
+    semaphore = asyncio.Semaphore(config.settings.slave.init_sources_concurrency)
+
+    async def load_source(source_id: str, source_config: configuration.SourceConfig) -> bool:
+        async with semaphore:
+            try:
+                source = _create_source(source_id, source_config)
+                await source.refresh_or_fetch()
+                _SOURCES[source_id] = source
+            except Exception:  # noqa: BLE001
+                _LOG.error("Cannot load the %s config", source_id, exc_info=True)
+                return False
+            return True
+
+    results = await asyncio.gather(
+        *[load_source(source_id, source_config) for source_id, source_config in to_reload.items()]
+    )
+    success = sum(results)
+    errors = len(results) - success
     return success, errors
 
 
@@ -181,12 +198,12 @@ async def _delete_source(source_id: str) -> None:
 def _filter_sources(
     source_configs: dict[str, configuration.SourceConfig],
 ) -> tuple[dict[str, configuration.SourceConfig], dict[str, configuration.SourceConfig]]:
-    if config.settings.tag_filter is None or mode.is_master():
+    if config.settings.slave.tag_filter is None or mode.is_master():
         return source_configs, {}
     result = {}
     filtered = {}
     for source_id, source_config in source_configs.items():
-        if config.settings.tag_filter in source_config.get("tags", []):
+        if config.settings.slave.tag_filter in source_config.get("tags", []):
             result[source_id] = source_config
         else:
             filtered[source_id] = source_config

--- a/app/tests/sources/test_registry.py
+++ b/app/tests/sources/test_registry.py
@@ -1,0 +1,72 @@
+import asyncio
+
+import pytest
+
+from shared_config_manager import config, configuration
+from shared_config_manager.sources import registry
+
+
+class _ConcurrencyProbe:
+    def __init__(self) -> None:
+        self.active = 0
+        self.max_active = 0
+        self._lock = asyncio.Lock()
+
+    async def run(self) -> None:
+        async with self._lock:
+            self.active += 1
+            self.max_active = max(self.max_active, self.active)
+        await asyncio.sleep(0.05)
+        async with self._lock:
+            self.active -= 1
+
+
+class _DummySource:
+    def __init__(
+        self,
+        source_id: str,
+        source_config: configuration.SourceConfig,
+        probe: _ConcurrencyProbe,
+    ) -> None:
+        self._source_id = source_id
+        self._source_config = source_config
+        self._probe = probe
+
+    async def refresh_or_fetch(self) -> None:
+        await self._probe.run()
+
+    async def delete(self) -> None:
+        pass
+
+    def get_config(self) -> configuration.SourceConfig:
+        return self._source_config
+
+
+@pytest.mark.asyncio
+async def test_do_handle_master_config_loads_sources_concurrently(monkeypatch: pytest.MonkeyPatch) -> None:
+    probe = _ConcurrencyProbe()
+
+    monkeypatch.setattr(registry, "_SOURCES", {})
+    monkeypatch.setattr(registry, "FILTERED_SOURCES", {})
+    monkeypatch.setattr(config.settings.slave, "tag_filter", None)
+    monkeypatch.setattr(config.settings.slave, "init_sources_concurrency", 2)
+
+    def create_source(
+        source_id: str,
+        source_config: configuration.SourceConfig,
+        is_master: bool = False,
+    ) -> _DummySource:
+        del is_master
+        return _DummySource(source_id, source_config, probe)
+
+    monkeypatch.setattr(registry, "_create_source", create_source)
+
+    master_config: configuration.Config = {
+        "sources": {f"source-{index}": {"type": "git"} for index in range(5)}
+    }
+
+    success, errors = await registry._do_handle_master_config(master_config)
+
+    assert success == 5
+    assert errors == 0
+    assert probe.max_active == 2

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,8 +13,8 @@ services:
       SCM__MASTER_CONFIG: |
         type: git
         repo: /repos/master
-      SCM__API_BASE_URL: http://api:8080/scm
-      SCM__TARGET: /config/api
+      SCM__SLAVE__API_BASE_URL: http://api:8080/scm
+      SCM__SLAVE__TARGET: /config/api
       SCM__ENV_PREFIXES: TEST_
       TEST_ENV: 42
       TEST_KEY: secret
@@ -49,8 +49,8 @@ services:
             template_engines:
               - type: shell
                 environment_variables: true
-      SCM__API_BASE_URL: http://api_inline:8080/scm
-      SCM__TARGET: /config/api-inline
+      SCM__SLAVE__API_BASE_URL: http://api_inline:8080/scm
+      SCM__SLAVE__TARGET: /config/api-inline
       C2C__REDIS__URL: redis://redis:6379/2
       C2C__REDIS__BROADCAST_PREFIX: broadcast_scm_inline_
     volumes_from:
@@ -64,8 +64,8 @@ services:
     environment: &scm_file_env
       <<: *scm_env
       SCM__MASTER_CONFIG: ''
-      SCM__API_BASE_URL: http://api_file:8080/scm
-      SCM__TARGET: /config/api-file
+      SCM__SLAVE__API_BASE_URL: http://api_file:8080/scm
+      SCM__SLAVE__TARGET: /config/api-file
       C2C__REDIS__URL: redis://redis:6379/3
       C2C__REDIS__BROADCAST_PREFIX: broadcast_scm_file_
     volumes_from:
@@ -78,7 +78,7 @@ services:
     image: camptocamp/shared_config_manager:latest
     environment:
       <<: *scm_env
-      SCM__TARGET: /config/slave
+      SCM__SLAVE__TARGET: /config/slave
     command: ['shared-config-slave']
     volumes_from:
       - tests:rw
@@ -90,8 +90,8 @@ services:
     image: camptocamp/shared_config_manager:latest
     environment:
       <<: *scm_env
-      SCM__TAG_FILTER: others
-      SCM__TARGET: /config/slave-other
+      SCM__SLAVE__TAG_FILTER: others
+      SCM__SLAVE__TARGET: /config/slave-other
       TEST_ENV: 42
     command: ['shared-config-slave']
     volumes_from:
@@ -104,7 +104,7 @@ services:
     image: camptocamp/shared_config_manager:latest
     environment:
       <<: *scm_file_env
-      SCM__TARGET: /config/slave-file
+      SCM__SLAVE__TARGET: /config/slave-file
     command: ['shared-config-slave']
     volumes_from:
       - tests:rw


### PR DESCRIPTION
## Summary
- move slave-related runtime options into a dedicated `slave` settings group so they are configured via `SCM__SLAVE__*` environment variables
- update source fetch/filter logic and startup checks to read from the new `config.settings.slave.*` fields
- speed up master-config reload by loading changed/new sources concurrently with a configurable `SCM__SLAVE__INIT_SOURCES_CONCURRENCY` limit, and add a test covering concurrency behavior